### PR TITLE
override LedDisplayTextField::getTextPosition in TD1 to allow text to be properly selected at all font sizes

### DIFF
--- a/src/TD1.cpp
+++ b/src/TD1.cpp
@@ -46,6 +46,14 @@ struct TDText : LedDisplayTextField {
 		LedDisplayTextField::onTextChange();
 		tdModule->sendText(text);
 	}
+	int getTextPosition(Vec mousePos) override {
+	    bndSetFont(font->handle);
+	    int textPos = bndIconLabelTextPosition(gVg, textOffset.x, textOffset.y,
+	      box.size.x - 2*textOffset.x, box.size.y - 2*textOffset.y,
+	      -1, fontSize, text.c_str(), mousePos.x, mousePos.y);
+	    bndSetFont(gGuiFont->handle);
+	    return textPos;
+	}
 	void draw(NVGcontext *vg) override {
 		nvgScissor(vg, 0, 0, box.size.x, box.size.y);
 		//Background


### PR DESCRIPTION
While working on a module of my own, I realized that when selecting text, the default LedDisplayTextField font size was being used in the selection logic.  This meant that the cursor was placed in wrong position when clicking into the larger text field.  I found a solution, and noticed that your TD1 module had the same problem.  I tried the same solution for TD2, which also has the same problem, but it didn't immediately work.  Studying your code helped me to understand how to make my own module - thanks very much!