### PR TITLE
Feature/remove unnecessary base constructor calls

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.1.1
+- 03-Dec-2019 Remove unnecessary base constructor calls
+
 ## v1.1.0
 - 26-Nov-2019 Add Secret Santa 2019
 - 26-Nov-2019 Add DO-1xx Digital Operator Devices

--- a/src/AG1.cpp
+++ b/src/AG1.cpp
@@ -51,7 +51,8 @@ struct AG_1 : DS_Module {
 };
 
 struct AG104 : SchemeModuleWidget {
-	AG104(AG_1<4> *module) : SchemeModuleWidget(module) {
+	AG104(AG_1<4> *module) {
+		setModule(module);
 		this->box.size = Vec(30, 380);
 		addChild(new SchemePanel(this->box.size));
 
@@ -89,7 +90,8 @@ struct AG104 : SchemeModuleWidget {
 };
 
 struct AG106 : SchemeModuleWidget {
-	AG106(AG_1<6> *module) : SchemeModuleWidget(module) {
+	AG106(AG_1<6> *module) {
+		setModule(module);
 		this->box.size = Vec(90, 380);
 		addChild(new SchemePanel(this->box.size));
 

--- a/src/AO1.cpp
+++ b/src/AO1.cpp
@@ -565,7 +565,8 @@ void AlgorithmMenu::onAction(const event::Action &e) {
 
 template <unsigned int x, unsigned int y>
 struct AOWidget : SchemeModuleWidget {
-	AOWidget(AO1<x,y> *module) : SchemeModuleWidget(module) {
+	AOWidget(AO1<x,y> *module) {
+		setModule(module);
 		this->box.size = Vec(y * 90 + 75, 380);
 		addChild(new SchemePanel(this->box.size));
 		for (unsigned int ix = 0; ix < x; ix++) {

--- a/src/BB1.cpp
+++ b/src/BB1.cpp
@@ -79,7 +79,8 @@ struct BB_1 : DS_Module {
 };
 
 struct BB120 : SchemeModuleWidget {
-	BB120(BB_1<20> *module) : SchemeModuleWidget(module) {
+	BB120(BB_1<20> *module) {
+		setModule(module);
 		this->box.size = Vec(60, 380);
 		addChild(new SchemePanel(this->box.size));
 

--- a/src/BP1.cpp
+++ b/src/BP1.cpp
@@ -2,7 +2,8 @@
 
 template <int x>
 struct BP1 : SchemeModuleWidget {
-	BP1(Module *module) : SchemeModuleWidget(module) {
+	BP1(Module *module) {
+		setModule(module);
 		SchemePanel *panel = new SchemePanel(Vec(x * 15, 380));
 		addChild(panel);
 		this->box.size = Vec(x * 15, 380);

--- a/src/DN1.cpp
+++ b/src/DN1.cpp
@@ -45,7 +45,8 @@ struct DN_1 : DS_Module {
 };
 
 struct DN112 : SchemeModuleWidget {
-	DN112(DN_1<12> *module) : SchemeModuleWidget(module) {
+	DN112(DN_1<12> *module) {
+		setModule(module);
 		this->box.size = Vec(30, 380);
 		addChild(new SchemePanel(this->box.size));
 

--- a/src/DO1.cpp
+++ b/src/DO1.cpp
@@ -570,7 +570,8 @@ struct DOWidget : SchemeModuleWidget {
 	ScrollWidget *collectionScrollWidget;
 	PLConnectorKnob *knobs[x + 4 * y];
 	PLBackground<x,y> *background;
-	DOWidget(DO1<x,y> *module) : SchemeModuleWidget(module) {
+	DOWidget(DO1<x,y> *module) {
+		setModule(module);
 		this->box.size = Vec(x * 30, 380);
 		addChild(new SchemePanel(this->box.size));
 		background = new PLBackground<x,y>();

--- a/src/DS.hpp
+++ b/src/DS.hpp
@@ -5,7 +5,7 @@ struct DS_Module : Module {
 	float voltage1 = 10.0f;
 	float midpoint();
 	float output(int);
-	DS_Module() : Module() {}
+	DS_Module() {}
 	json_t *dataToJson() override;
 	void dataFromJson(json_t *) override;
 	void onReset() override;

--- a/src/EO1.cpp
+++ b/src/EO1.cpp
@@ -424,7 +424,8 @@ struct EO_Measure_Vert : EO_Measure {
 
 struct EO102 : SchemeModuleWidget {
 	LightButton *paramRun;
-	EO102(EO_102 *module) : SchemeModuleWidget(module) {
+	EO102(EO_102 *module) {
+		setModule(module);
 		this->box.size = Vec(405, 380);
 		addChild(new SchemePanel(this->box.size));
 

--- a/src/FF1.cpp
+++ b/src/FF1.cpp
@@ -85,7 +85,8 @@ struct FF_1 : DS_Module {
 };
 
 struct FF110 : SchemeModuleWidget {
-	FF110(FF_1<10> *module) : SchemeModuleWidget(module) {
+	FF110(FF_1<10> *module) {
+		setModule(module);
 		this->box.size = Vec(30, 380);
 		addChild(new SchemePanel(this->box.size));
 
@@ -118,7 +119,8 @@ struct FF110 : SchemeModuleWidget {
 };
 
 struct FF120 : SchemeModuleWidget {
-	FF120(FF_1<20> *module) : SchemeModuleWidget(module) {
+	FF120(FF_1<20> *module) {
+		setModule(module);
 		this->box.size = Vec(60, 380);
 		addChild(new SchemePanel(this->box.size));
 

--- a/src/FF2.cpp
+++ b/src/FF2.cpp
@@ -85,7 +85,8 @@ struct FF_2 : DS_Module {
 };
 
 struct FF206 : SchemeModuleWidget {
-	FF206(FF_2<6> *module) : SchemeModuleWidget(module) {
+	FF206(FF_2<6> *module) {
+		setModule(module);
 		this->box.size = Vec(30, 380);
 		addChild(new SchemePanel(this->box.size));
 
@@ -123,7 +124,8 @@ struct FF206 : SchemeModuleWidget {
 };
 
 struct FF212 : SchemeModuleWidget {
-	FF212(FF_2<12> *module) : SchemeModuleWidget(module) {
+	FF212(FF_2<12> *module) {
+		setModule(module);
 		this->box.size = Vec(90, 380);
 		addChild(new SchemePanel(this->box.size));
 

--- a/src/LA1.cpp
+++ b/src/LA1.cpp
@@ -335,7 +335,8 @@ struct LA_Measure : TransparentWidget {
 
 struct LA108 : SchemeModuleWidget {
 	LightButton *resetButton;
-	LA108(LA_108 *module) : SchemeModuleWidget(module) {
+	LA108(LA_108 *module) {
+		setModule(module);
 		this->box.size = Vec(300, 380);
 		addChild(new SchemePanel(this->box.size));
 

--- a/src/LD1.cpp
+++ b/src/LD1.cpp
@@ -98,7 +98,8 @@ struct LDParentMenuItem : MenuItem {
 
 struct LD103 : SchemeModuleWidget {
 	static const int deviceCount = 3;	
-	LD103(LD_1<deviceCount> *module) : SchemeModuleWidget(module) {
+	LD103(LD_1<deviceCount> *module) {
+		setModule(module);
 		this->box.size = Vec(30, 380);
 		addChild(new SchemePanel(this->box.size));
 
@@ -148,7 +149,8 @@ struct LD103 : SchemeModuleWidget {
 
 struct LD106 : SchemeModuleWidget {
 	static const int deviceCount = 6;	
-	LD106(LD_1<deviceCount> *module) : SchemeModuleWidget(module) {
+	LD106(LD_1<deviceCount> *module) {
+		setModule(module);
 		this->box.size = Vec(90, 380);
 		addChild(new SchemePanel(this->box.size));
 

--- a/src/NG1.cpp
+++ b/src/NG1.cpp
@@ -30,7 +30,8 @@ struct NG_1 : DS_Module {
 };
 
 struct NG106 : SchemeModuleWidget {
-	NG106(NG_1<6> *module) : SchemeModuleWidget(module) {
+	NG106(NG_1<6> *module) {
+		setModule(module);
 		this->box.size = Vec(30, 380);
 		addChild(new SchemePanel(this->box.size));
 
@@ -62,7 +63,8 @@ struct NG106 : SchemeModuleWidget {
 };
 
 struct NG112 : SchemeModuleWidget {
-	NG112(NG_1<12> *module) : SchemeModuleWidget(module) {
+	NG112(NG_1<12> *module) {
+		setModule(module);
 		this->box.size = Vec(90, 380);
 		addChild(new SchemePanel(this->box.size));
 

--- a/src/OG1.cpp
+++ b/src/OG1.cpp
@@ -41,7 +41,8 @@ struct OG_1 : DS_Module {
 };
 
 struct OG104 : SchemeModuleWidget {
-	OG104(OG_1<4> *module) : SchemeModuleWidget(module) {
+	OG104(OG_1<4> *module) {
+		setModule(module);
 		this->box.size = Vec(30, 380);
 		addChild(new SchemePanel(this->box.size));
 
@@ -79,7 +80,8 @@ struct OG104 : SchemeModuleWidget {
 };
 
 struct OG106 : SchemeModuleWidget {
-	OG106(OG_1<6> *module) : SchemeModuleWidget(module) {
+	OG106(OG_1<6> *module) {
+		setModule(module);
 		this->box.size = Vec(90, 380);
 		addChild(new SchemePanel(this->box.size));
 

--- a/src/PG1.cpp
+++ b/src/PG1.cpp
@@ -44,7 +44,8 @@ struct PG_1 : DS_Module {
 };
 
 struct PG104 : SchemeModuleWidget {
-	PG104(PG_1<4> *module) : SchemeModuleWidget(module) {
+	PG104(PG_1<4> *module) { 
+		setModule(module);
 		this->box.size = Vec(30, 380);
 		addChild(new SchemePanel(this->box.size));
 
@@ -79,7 +80,8 @@ struct PG104 : SchemeModuleWidget {
 };
 
 struct PG112 : SchemeModuleWidget {
-	PG112(PG_1<12> *module) : SchemeModuleWidget(module) {
+	PG112(PG_1<12> *module) { 
+		setModule(module);
 		this->box.size = Vec(120, 380);
 		addChild(new SchemePanel(this->box.size));
 

--- a/src/PO1.cpp
+++ b/src/PO1.cpp
@@ -384,7 +384,7 @@ void PO_101::process(const ProcessArgs &args) {
 }
 
 struct PO_Layout : SchemeModuleWidget {
-	PO_Layout(PO_101 *module) : SchemeModuleWidget(module) {}
+	PO_Layout() {};
 	void Layout() {
 		addParam(createParamCentered<MedKnob<LightKnob>>(Vec(85, 58), module, PO_101::PARAM_FINE));
 		addParam(createParamCentered<NarrowKnob<SnapKnob<MedKnob<LightKnob>>>>(Vec(140, 58), module, PO_101::PARAM_WAVE));
@@ -468,7 +468,8 @@ struct PO_Layout : SchemeModuleWidget {
 };
 
 struct PO101 : PO_Layout {
-	PO101(PO_101 *module) : PO_Layout(module) {
+	PO101(PO_101 *module) {
+		setModule(module);
 		this->box.size = Vec(180, 380);
 		addChild(new SchemePanel(this->box.size));
 		addParam(createParam<MedKnob<LightKnob>>(Vec(11, 39), module, PO_101::PARAM_TUNE));
@@ -481,7 +482,8 @@ struct PO101 : PO_Layout {
 };
 
 struct PO102 : PO_Layout {
-	PO102(PO_102 *module) : PO_Layout(module) {
+	PO102(PO_102 *module) {
+		setModule(module);
 		this->box.size = Vec(180, 380);
 		addChild(new SchemePanel(this->box.size));
 		addParam(createParam<MedKnob<LightKnob>>(Vec(11, 39), module, PO_101::PARAM_TUNE));

--- a/src/PO2.cpp
+++ b/src/PO2.cpp
@@ -254,7 +254,8 @@ void PO_204::process(const ProcessArgs &args) {
 }
 
 struct PO204 : SchemeModuleWidget {
-	PO204(PO_204 *module) : SchemeModuleWidget(module) {
+	PO204(PO_204 *module) {
+		setModule(module);
 		this->box.size = Vec(150, 380);
 		addChild(new SchemePanel(this->box.size));
 		addParam(createParamCentered<MedKnob<LightKnob>>(Vec(79, 38), module, PO_204::PARAM_TUNE));

--- a/src/SS1.cpp
+++ b/src/SS1.cpp
@@ -10,7 +10,8 @@ struct SS_112 : Module {
 };
 
 struct SS112 : SchemeModuleWidget {
-	SS112(SS_112 *module) : SchemeModuleWidget(module) {
+	SS112(SS_112 *module) {
+		setModule(module);
 		this->box.size = Vec(30, 380);
 		addChild(new SchemePanel(this->box.size));
 		for (int i = 0; i < SS_112::deviceCount; i++) {
@@ -50,7 +51,8 @@ struct SS_208 : Module {
 };
 
 struct SS208 : SchemeModuleWidget {
-	SS208(SS_208 *module) : SchemeModuleWidget(module) {
+	SS208(SS_208 *module) {
+		setModule(module);
 		this->box.size = Vec(30, 380);
 		addChild(new SchemePanel(this->box.size));
 		for (int i = 0; i < SS_208::deviceCount; i++) {
@@ -101,7 +103,8 @@ struct SS_212 : Module {
 };
 
 struct SS212 : SchemeModuleWidget {
-	SS212(SS_212 *module) : SchemeModuleWidget(module) {
+	SS212(SS_212 *module) {
+		setModule(module);
 		this->box.size = Vec(30, 380);
 		addChild(new SchemePanel(this->box.size));
 		for (int i = 0; i < SS_212::deviceCount; i++) {
@@ -162,7 +165,8 @@ struct SS_221 : Module {
 };
 
 struct SS221 : SchemeModuleWidget {
-	SS221(SS_221 *module) : SchemeModuleWidget(module) {
+	SS221(SS_221 *module) {
+		setModule(module);
 		this->box.size = Vec(75, 380);
 		addChild(new SchemePanel(this->box.size));
 		for (int i = 0; i < SS_221::deviceCount; i++) {
@@ -211,7 +215,8 @@ struct SS_220 : Module {
 };
 
 struct SS220 : SchemeModuleWidget {
-	SS220(SS_220 *module) : SchemeModuleWidget(module) {
+	SS220(SS_220 *module) {
+		setModule(module);
 		this->box.size = Vec(300, 380);
 		addChild(new SchemePanel(this->box.size));
 		for (int j = 0; j < SS_220::deviceSetCount; j++) {

--- a/src/TD1.cpp
+++ b/src/TD1.cpp
@@ -140,7 +140,8 @@ void TDInput::received(std::string pluginName, std::string moduleName, json_t *r
 struct TD116 : SchemeModuleWidget {
 	TD1Text *textField;
 
-	TD116(TD_116 *module) : SchemeModuleWidget(module) {
+	TD116(TD_116 *module) {
+		setModule(module);
 		this->box.size = Vec(240, 380);
 		addChild(new SchemePanel(this->box.size));
 

--- a/src/TD2.cpp
+++ b/src/TD2.cpp
@@ -68,7 +68,8 @@ struct TD_202 : Module {
 struct TD202 : SchemeModuleWidget {
 	TDVText *textField;
 
-	TD202(Module *module) : SchemeModuleWidget(module) {
+	TD202(Module *module) {
+		setModule(module);
 		this->box.size = Vec(30, 380);
 		addChild(new SchemePanel(this->box.size));
 

--- a/src/TD3.cpp
+++ b/src/TD3.cpp
@@ -69,7 +69,8 @@ struct TD3Text : SubText {
 struct TD316 : SchemeModuleWidget {
 	TD3Text *textField;
 
-	TD316(TD_316 *module) : SchemeModuleWidget(module) {
+	TD316(TD_316 *module) {
+		setModule(module);
 		this->box.size = Vec(240, 380);
 		addChild(new SchemePanel(this->box.size));
 

--- a/src/TF1.cpp
+++ b/src/TF1.cpp
@@ -137,7 +137,8 @@ struct RGBLight : GrayModuleLightWidget {
 
 
 struct TF101 : SchemeModuleWidget {
-	TF101(TF<true> *module) : SchemeModuleWidget(module) {
+	TF101(TF<true> *module) {
+		setModule(module);
 		this->box.size = Vec(90, 380);
 		addChild(new SchemePanel(this->box.size));
 
@@ -190,7 +191,8 @@ struct TF101 : SchemeModuleWidget {
 };
 
 struct TF102 : SchemeModuleWidget {
-	TF102(TF<false> *module) : SchemeModuleWidget(module) {
+	TF102(TF<false> *module) {
+		setModule(module);
 		this->box.size = Vec(30, 380);
 		addChild(new SchemePanel(this->box.size));
 

--- a/src/TM1.cpp
+++ b/src/TM1.cpp
@@ -111,7 +111,8 @@ void TM_105::process(const ProcessArgs &args) {
 }
 
 struct TM105 : SchemeModuleWidget {
-	TM105(TM_105 *module) : SchemeModuleWidget(module) {
+	TM105(TM_105 *module) {
+		setModule(module);
 		this->box.size = Vec(30, 380);
 		addChild(new SchemePanel(this->box.size));
 		for (unsigned int i = 0; i < 5; i++) {

--- a/src/WK12.cpp
+++ b/src/WK12.cpp
@@ -321,7 +321,8 @@ struct WK_Param : MedKnob<LightKnob> {
 };
 
 struct WK101 : SchemeModuleWidget {
-	WK101(WK_101 *module) : SchemeModuleWidget(module) {
+	WK101(WK_101 *module) {
+		setModule(module);
 		this->box.size = Vec(150, 380);
 		addChild(new SchemePanel(this->box.size));
 
@@ -624,7 +625,8 @@ void WK205_InputPort::received(std::string pluginName, std::string moduleName, j
 }
 
 struct WK205 : SchemeModuleWidget {
-	WK205(WK_205 *module) : SchemeModuleWidget(module) {
+	WK205(WK_205 *module) {
+		setModule(module);
 		this->box.size = Vec(30, 380);
 		addChild(new SchemePanel(this->box.size));
 

--- a/src/WM1.cpp
+++ b/src/WM1.cpp
@@ -365,7 +365,8 @@ struct WM101 : SizeableModuleWidget {
 	ScrollWidget *collectionScrollWidget;
 	
 	ScrollWidget *scrollWidget;
-	WM101(Module *module) : SizeableModuleWidget(module, 150) {
+	WM101(Module *module) : SizeableModuleWidget(150) {
+		setModule(module);
 		minButton = new MinButton();
 		minButton->box.pos = Vec(140,180);
 		minButton->mw = this;

--- a/src/XF-101.cpp
+++ b/src/XF-101.cpp
@@ -60,7 +60,8 @@ void XF_101::process(const ProcessArgs &args) {
 }
 
 struct XF101 : SchemeModuleWidget {
-	XF101(XF_101 *module) : SchemeModuleWidget(module) {
+	XF101(XF_101 *module) {
+		setModule(module);
 		XF_LightKnob *fader;
 		this->box.size = Vec(180, 380);
 		addChild(new SchemePanel(this->box.size));

--- a/src/XF-102.cpp
+++ b/src/XF-102.cpp
@@ -83,7 +83,8 @@ void XF_102::process(const ProcessArgs &args) {
 }
 
 struct XF102 : SchemeModuleWidget {
-	XF102(XF_102 *module) : SchemeModuleWidget(module) {
+	XF102(XF_102 *module) {
+		setModule(module);
 		XF_LightKnob *fader;
 		this->box.size = Vec(180, 380);
 		addChild(new SchemePanel(this->box.size));

--- a/src/XF-104.cpp
+++ b/src/XF-104.cpp
@@ -91,7 +91,8 @@ void XF_104::process(const ProcessArgs &args) {
 }
 
 struct XF104 : SchemeModuleWidget {
-	XF104(XF_104 *module) : SchemeModuleWidget(module) {
+	XF104(XF_104 *module) {
+		setModule(module);
 		XF_LightKnob *fader;
 		this->box.size = Vec(180, 380);
 		addChild(new SchemePanel(this->box.size));

--- a/src/XF-201.cpp
+++ b/src/XF-201.cpp
@@ -61,7 +61,8 @@ void XF_201::process(const ProcessArgs &args) {
 }
 
 struct XF201 : SchemeModuleWidget {
-	XF201(XF_201 *module) : SchemeModuleWidget(module) {
+	XF201(XF_201 *module) {
+		setModule(module);
 		XF_LightKnob *fader;
 		this->box.size = Vec(120, 380);
 		addChild(new SchemePanel(this->box.size));
@@ -122,7 +123,8 @@ struct XF201 : SchemeModuleWidget {
 };
 
 struct XF301 : SchemeModuleWidget {
-	XF301(XF_201 *module) : SchemeModuleWidget(module) {
+	XF301(XF_201 *module) {
+		setModule(module);
 		XF_LightKnob *fader;
 		this->box.size = Vec(120, 380);
 		addChild(new SchemePanel(this->box.size));

--- a/src/XF-202.cpp
+++ b/src/XF-202.cpp
@@ -62,7 +62,8 @@ void XF_202::process(const ProcessArgs &args) {
 }
 
 struct XF202 : SchemeModuleWidget {
-	XF202(XF_202 *module) : SchemeModuleWidget(module) {
+	XF202(XF_202 *module) {
+		setModule(module);
 		XF_LightKnob *fader;
 		this->box.size = Vec(120, 380);
 		addChild(new SchemePanel(this->box.size));

--- a/src/XG1.cpp
+++ b/src/XG1.cpp
@@ -41,7 +41,8 @@ struct XG_1 : DS_Module {
 };
 
 struct XG104 : SchemeModuleWidget {
-	XG104(XG_1<4> *module) : SchemeModuleWidget(module) {
+	XG104(XG_1<4> *module) {
+		setModule(module);
 		this->box.size = Vec(30, 380);
 		addChild(new SchemePanel(this->box.size));
 
@@ -79,7 +80,8 @@ struct XG104 : SchemeModuleWidget {
 };
 
 struct XG106 : SchemeModuleWidget {
-	XG106(XG_1<6> *module) : SchemeModuleWidget(module) {
+	XG106(XG_1<6> *module) {
+		setModule(module);
 		this->box.size = Vec(90, 380);
 		addChild(new SchemePanel(this->box.size));
 

--- a/src/XXX.cpp
+++ b/src/XXX.cpp
@@ -174,7 +174,8 @@ struct CandyCanleWidget : CableWidget {
 
 struct XX219 : SchemeModuleWidget {
 
-	XX219(Module *module) : SchemeModuleWidget(module) {
+	XX219(Module *module) {
+		setModule(module);
 		this->box.size = Vec(15, 380);
 		addChild(new SchemePanel(this->box.size));
 	}

--- a/src/shared/SizeableModuleWidget.cpp
+++ b/src/shared/SizeableModuleWidget.cpp
@@ -1,7 +1,7 @@
 #include <settings.hpp>
 #include "../SubmarineFree.hpp"
 
-SizeableModuleWidget::SizeableModuleWidget(Module *module, float size) : SchemeModuleWidget(module) {
+SizeableModuleWidget::SizeableModuleWidget(float size) {
 	fullSize = size;
 	this->box.size = Vec(fullSize, 380);
 	panel = new SchemePanel(this->box.size);

--- a/src/shared/components.hpp
+++ b/src/shared/components.hpp
@@ -237,9 +237,7 @@ namespace scheme {
 }
 
 struct SchemeModuleWidget : app::ModuleWidget {
-	SchemeModuleWidget(Module *module): ModuleWidget() {
-		setModule(module);
-	}
+	SchemeModuleWidget() {}
 	void appendContextMenu(Menu *menu) override;
 	void drawBackground(NVGcontext *vg);
 	void drawLogo(NVGcontext *vg, float left, float top, float scale, float rotate);
@@ -391,7 +389,7 @@ struct SizeableModuleWidget : SchemeModuleWidget {
 	bool stabilized = false;
 	float fullSize = 0;
 	SchemePanel *panel;
-	SizeableModuleWidget(Module *module, float size);
+	SizeableModuleWidget(float size);
 	void Resize();
 	void Minimize(bool minimize);
 	void ShiftOthers(float delta);


### PR DESCRIPTION
Under v0.6 ModuleWidget was constructed with a Module.
This is no longer the case. Instances of ModuleWidgets are expected to be constructed that way, but should call setModule explicitly so, the parameter-free Module constructor can be used instead