### PR TITLE
Add a few color sets (conventions) found online

### DIFF
--- a/src/WM1.cpp
+++ b/src/WM1.cpp
@@ -1421,7 +1421,15 @@ struct WM101 : SizeableModuleWidget {
 		menu->addChild(redo);
 	}
 	void addCollectionMenu(ColorCollectionButton *cb) {
+		// by convention, place at the current mouse location
+		addCollectionMenu(cb, false);
+	}
+	void addCollectionMenu(ColorCollectionButton *cb, bool forcePosition) {
 		Menu *menu = createMenu();
+		if (forcePosition) {
+			// put the name field under the mouse
+			menu->box.pos = APP->window->mousePos.minus(Vec(100, 12));
+		}
 		EventParamField *paramField = new EventParamField();
 		paramField->box.size.x = 100;
 		paramField->setText(cb->name);
@@ -1606,6 +1614,17 @@ struct WM101 : SizeableModuleWidget {
 				}
 			}
 		));
+		promptForCollectionName(index);
+	}
+	void promptForCollectionName(unsigned int index) {
+		// jump to collections list (if not already visible)
+		collectionsDialog();
+		ColorCollectionButton *cb = findCollectionButton(index);
+		// TODO: scroll to show the n-th collection (vs. jump to end of list)
+		math::Rect box = math::Rect(math::Vec(INFINITY, INFINITY), math::Vec(INFINITY, INFINITY));
+		collectionScrollWidget->scrollTo(box);
+		// prompt for this collection's name/position/etc.
+		addCollectionMenu(cb, true);  // use sensible menu position
 	}
 	void deleteCollection(ColorCollectionButton *cb) {
 		unsigned int index = cb->index();

--- a/src/WM1.cpp
+++ b/src/WM1.cpp
@@ -287,6 +287,9 @@ struct WireButton : EventWidgetButtonBase {
 struct ColorCollectionButton : EventWidgetButtonBase {
 	std::string name;
 	std::vector<NVGcolor> colors;
+	// add a dedicated tooltip to show color descriptions on rollover
+	ui::Tooltip* tooltip;
+	unsigned int counter = 0;  // just for testing
 	
 	void draw(const DrawArgs &args) override {
 		if (!name.empty()) {
@@ -303,7 +306,7 @@ struct ColorCollectionButton : EventWidgetButtonBase {
 			NVGcolor col = color;
 			col.a = 1.0f;
 			nvgBeginPath(args.vg);
-			nvgRect(args.vg, left, 15, width, 5);
+			nvgRect(args.vg, left, 15, width, 8);
 			nvgFillColor(args.vg, col);
 			nvgFill(args.vg);
 			left += width;
@@ -318,6 +321,50 @@ struct ColorCollectionButton : EventWidgetButtonBase {
 			i++;
 		}
 		return 0;
+	}
+
+	void onEnter(const event::Enter &e) override {
+		OpaqueWidget::onEnter(e);
+		//e.consume(this);
+	}
+	void onHover(const event::Hover &e) override {
+		if (!tooltip) {
+			counter++;
+			SubTooltip *stt = new SubTooltip();
+			tooltip = stt;
+			APP->scene->addChild(tooltip);
+			stt->stepLambda = [=]() {
+				tooltip->text = "FOO-" + std::to_string(counter);
+				stt->Tooltip::step();
+				// place the tooltip just below the collection's color strip
+				tooltip->box.pos = this->getAbsoluteOffset(this->box.size).minus(Vec(110, 1)).round();
+			};
+		}
+		/* TODO: adapt logic above to show the description for the current target color chip
+		float width = box.size.x - 25.0f;
+		width = width / colors.size();
+		float left = 0.0f;
+		for (NVGcolor color : colors) {
+			NVGcolor col = color;
+			col.a = 1.0f;
+			nvgBeginPath(args.vg);
+			nvgRect(args.vg, left, 15, width, 8);
+			nvgFillColor(args.vg, col);
+			nvgFill(args.vg);
+			left += width;
+		}
+		*/
+		OpaqueWidget::onHover(e);
+		//e.consume(this);
+	}
+	void onLeave(const event::Leave &e) override {
+		if (tooltip) {
+			APP->scene->removeChild(tooltip);
+			delete tooltip;
+			tooltip = NULL;
+		}
+		OpaqueWidget::onLeave(e);
+		//e.consume(this);
 	}
 };
 
@@ -1016,10 +1063,10 @@ struct WM101 : SizeableModuleWidget {
 		return wb;
 	}
 	ColorCollectionButton *addCollection(std::string name, std::vector<NVGcolor> colors) {
-		float y = collectionScrollWidget->container->children.size() * 21;
+		float y = collectionScrollWidget->container->children.size() * 24;
 		ColorCollectionButton *btn = new ColorCollectionButton();
 		btn->box.pos = Vec(0, y);
-		btn->box.size = Vec(collectionScrollWidget->box.size.x, 21);
+		btn->box.size = Vec(collectionScrollWidget->box.size.x, 24);
 		btn->name = name;
 		btn->colors = colors;
 		btn->rightClickHandler = [=]() {
@@ -1571,7 +1618,7 @@ struct WM101 : SizeableModuleWidget {
 			EventWidgetMenuItem *mu = new EventWidgetMenuItem();
 			mu->text = "Move Up";
 			mu->clickHandler = [=]() {
-				this->swap(wb->box.pos.y / 21 - 1);
+				this->swap(wb->box.pos.y / 24 - 1);
 			};
 			menu->addChild(mu);
 		}
@@ -1579,7 +1626,7 @@ struct WM101 : SizeableModuleWidget {
 			EventWidgetMenuItem *md = new EventWidgetMenuItem();
 			md->text = "Move Down";
 			md->clickHandler = [=]() {
-				this->swap(wb->box.pos.y / 21);
+				this->swap(wb->box.pos.y / 24);
 			};
 			menu->addChild(md);
 		}
@@ -1696,7 +1743,7 @@ struct WM101 : SizeableModuleWidget {
 		unsigned int y = 0;
 		for (Widget *widget : collectionScrollWidget->container->children) {
 			widget->box.pos.y = y;
-			y += 21;
+			y += 24;
 		}
 	}
 	void swap(int i) {

--- a/src/WM1.cpp
+++ b/src/WM1.cpp
@@ -287,9 +287,6 @@ struct WireButton : EventWidgetButtonBase {
 struct ColorCollectionButton : EventWidgetButtonBase {
 	std::string name;
 	std::vector<NVGcolor> colors;
-	// add a dedicated tooltip to show color descriptions on rollover
-	ui::Tooltip* tooltip;
-	unsigned int counter = 0;  // just for testing
 	
 	void draw(const DrawArgs &args) override {
 		if (!name.empty()) {
@@ -306,7 +303,7 @@ struct ColorCollectionButton : EventWidgetButtonBase {
 			NVGcolor col = color;
 			col.a = 1.0f;
 			nvgBeginPath(args.vg);
-			nvgRect(args.vg, left, 15, width, 8);
+			nvgRect(args.vg, left, 15, width, 5);
 			nvgFillColor(args.vg, col);
 			nvgFill(args.vg);
 			left += width;
@@ -321,50 +318,6 @@ struct ColorCollectionButton : EventWidgetButtonBase {
 			i++;
 		}
 		return 0;
-	}
-
-	void onEnter(const event::Enter &e) override {
-		OpaqueWidget::onEnter(e);
-		//e.consume(this);
-	}
-	void onHover(const event::Hover &e) override {
-		if (!tooltip) {
-			counter++;
-			SubTooltip *stt = new SubTooltip();
-			tooltip = stt;
-			APP->scene->addChild(tooltip);
-			stt->stepLambda = [=]() {
-				tooltip->text = "FOO-" + std::to_string(counter);
-				stt->Tooltip::step();
-				// place the tooltip just below the collection's color strip
-				tooltip->box.pos = this->getAbsoluteOffset(this->box.size).minus(Vec(110, 1)).round();
-			};
-		}
-		/* TODO: adapt logic above to show the description for the current target color chip
-		float width = box.size.x - 25.0f;
-		width = width / colors.size();
-		float left = 0.0f;
-		for (NVGcolor color : colors) {
-			NVGcolor col = color;
-			col.a = 1.0f;
-			nvgBeginPath(args.vg);
-			nvgRect(args.vg, left, 15, width, 8);
-			nvgFillColor(args.vg, col);
-			nvgFill(args.vg);
-			left += width;
-		}
-		*/
-		OpaqueWidget::onHover(e);
-		//e.consume(this);
-	}
-	void onLeave(const event::Leave &e) override {
-		if (tooltip) {
-			APP->scene->removeChild(tooltip);
-			delete tooltip;
-			tooltip = NULL;
-		}
-		OpaqueWidget::onLeave(e);
-		//e.consume(this);
 	}
 };
 
@@ -1063,10 +1016,10 @@ struct WM101 : SizeableModuleWidget {
 		return wb;
 	}
 	ColorCollectionButton *addCollection(std::string name, std::vector<NVGcolor> colors) {
-		float y = collectionScrollWidget->container->children.size() * 24;
+		float y = collectionScrollWidget->container->children.size() * 21;
 		ColorCollectionButton *btn = new ColorCollectionButton();
 		btn->box.pos = Vec(0, y);
-		btn->box.size = Vec(collectionScrollWidget->box.size.x, 24);
+		btn->box.size = Vec(collectionScrollWidget->box.size.x, 21);
 		btn->name = name;
 		btn->colors = colors;
 		btn->rightClickHandler = [=]() {
@@ -1618,7 +1571,7 @@ struct WM101 : SizeableModuleWidget {
 			EventWidgetMenuItem *mu = new EventWidgetMenuItem();
 			mu->text = "Move Up";
 			mu->clickHandler = [=]() {
-				this->swap(wb->box.pos.y / 24 - 1);
+				this->swap(wb->box.pos.y / 21 - 1);
 			};
 			menu->addChild(mu);
 		}
@@ -1626,7 +1579,7 @@ struct WM101 : SizeableModuleWidget {
 			EventWidgetMenuItem *md = new EventWidgetMenuItem();
 			md->text = "Move Down";
 			md->clickHandler = [=]() {
-				this->swap(wb->box.pos.y / 24);
+				this->swap(wb->box.pos.y / 21);
 			};
 			menu->addChild(md);
 		}
@@ -1743,7 +1696,7 @@ struct WM101 : SizeableModuleWidget {
 		unsigned int y = 0;
 		for (Widget *widget : collectionScrollWidget->container->children) {
 			widget->box.pos.y = y;
-			y += 24;
+			y += 21;
 		}
 	}
 	void swap(int i) {

--- a/src/WM1.cpp
+++ b/src/WM1.cpp
@@ -1092,6 +1092,37 @@ struct WM101 : SizeableModuleWidget {
 			addColor(color, true);
 		}
 		
+		// add some useful color conventions
+
+		// Omri Cohen's colors as shown here  <https://github.com/david-c14/ModularFungi/blob/master/res/Colors.png>
+		scrollWidget->container->clearChildren();
+		addColor(color::fromHexString("#c91847"), false);  // audio
+		addColor(color::fromHexString("#0986ad"), false);  // clock/trigger/gate
+		addColor(color::fromHexString("#c9b70e"), false);  // volt/octave
+		addColor(color::fromHexString("#0c8e15"), false);  // modulation
+		addCollection(std::string("Modular Fungi"), currentCollection());
+
+		// jack color conventions used in NYSTHI modules  <https://github.com/patman023/nysthimanual/blob/master/pages/basics/basics.md>
+		scrollWidget->container->clearChildren();
+		addColor(color::fromHexString("#dddddd"), false);  // audio
+		addColor(color::fromHexString("#3c82dc"), false);  // control voltage
+		addColor(color::fromHexString("#fad12d"), false);  // gate
+		addColor(color::fromHexString("#dc7814"), false);  // pulse/trigger
+		addColor(color::fromHexString("#800080"), false);  // sync
+		addCollection(std::string("NYSTHI"), currentCollection());
+
+		// jack color conventions used in TheXOR modules  <https://github.com/The-XOR/RackPlugins>
+		scrollWidget->container->clearChildren();
+		addColor(color::fromHexString("#ff0000"), false);  // clock
+		addColor(color::fromHexString("#fffc0d"), false);  // reset
+		addColor(color::fromHexString("#008000"), false);  // control voltage
+		addColor(color::fromHexString("#f1f1f1"), false);  // gate
+		addColor(color::fromHexString("#000000"), false);  // modulation
+		addColor(color::fromHexString("#0000ff"), false);  // trigger
+		addColor(color::fromHexString("#ff5555"), false);  // expansion
+		addCollection(std::string("TheXOR"), currentCollection());
+
+		// add default colors (will remain active)
 		addColor(nvgRGB(0xff, 0xae, 0xc9), false);
 		addColor(nvgRGB(0xb7, 0x00, 0xb5), false);
 		addColor(nvgRGB(0x80, 0x80, 0x80), false);


### PR DESCRIPTION
I've adapted a few of the wire-color conventions listed in [this discussion](https://community.vcvrack.com/t/choosing-cable-colors-in-vcv-1-0/4155).

These will appear as options in WM-101 *if* there isn't already a `WM-101.json` file for this user. The existing default colors will then be active, just as before.

Ideally we'd have a feature to add/merge these shared color sets with the user's saved settings.